### PR TITLE
Changed the order of the parameter if's

### DIFF
--- a/SpoofMAC.py
+++ b/SpoofMAC.py
@@ -62,7 +62,10 @@ def setMACAddress(interface, address):
 	print("If both addresses are the same, run 'ifconfig {} | grep ether' in a few seconds.".format(interface))
 
 if __name__ == "__main__":
-	if len(sys.argv) == 1:
+	if len(sys.argv) >= 2 and sys.argv[1] == "-h":
+		print "sudo python SpoofMAC.py <interface> <mac_address> (For <interface>, use en0 for wired or en1 for wireless)"
+		print "Example: sudo python SpoofMAC.py en1 12:12:12:12:12:12"
+	elif len(sys.argv) == 1:
 		print "Using default MAC adresses for en0 and en1."
 		setMACAddress("en0", WIRED_INTERFACE)
 		setMACAddress("en1", WIRELESS_INTERFACE)
@@ -76,9 +79,6 @@ if __name__ == "__main__":
 		interface = sys.argv[1]
 		address = sys.argv[2]
 		setMACAddress(interface, address)
-	elif sys.argv[1] == "-h":
-		print "sudo python SpoofMAC.py <interface> <mac_address> (For <interface>, use en0 for wired or en1 for wireless)"
-		print "Example: sudo python SpoofMAC.py en1 12:12:12:12:12:12"
 	else:
 		print "Wrong number of arguments."
 


### PR DESCRIPTION
The way it was ordered previously did not allow for easy access of -h ('SpoofMAC -h' would jump in the 'Using random MAC'-case), but now it does!
