### PR TITLE
Split command when sending to subprocess.call on Linux platforms.

### DIFF
--- a/spoofmac/interface.py
+++ b/spoofmac/interface.py
@@ -105,10 +105,10 @@ class LinuxSpoofer(OsSpoofer):
         """
         # turn off device & set mac
         cmd = "ifconfig {} down hw ether {}".format(device, mac)
-        subprocess.call(cmd)
+        subprocess.call(cmd.split())
         # turn on device
         cmd = "ifconfig {} up".format(device)
-        subprocess.call(cmd)
+        subprocess.call(cmd.split())
 
 class WindowsSpoofer(OsSpoofer):
     """


### PR DESCRIPTION
On the Linux platform (tested on Ubuntu 14.04, but this probably affects other platforms as well) the subprocess.call routine expects the call and its arguments split in a list. Behavior when using the entire string is platform dependent (unlike when sending a list) and, in this case, causes an error when attempting to randomize the MAC. Behavior using a list is platform independent so should generally be preferred. This makes that change for the Linux platform.
