### PR TITLE
Use LinuxSpooferIP() if /bin/ip exists

### DIFF
--- a/spoofmac/interface.py
+++ b/spoofmac/interface.py
@@ -493,7 +493,7 @@ def get_os_spoofer():
     elif sys.platform == 'darwin':
         spoofer = MacSpoofer()
     elif sys.platform.startswith('linux'):
-        if os.path.exists("/usr/bin/ip"):
+        if os.path.exists("/usr/bin/ip") or os.path.exists("/bin/ip"):
             spoofer = LinuxSpooferIP()
         else:
             spoofer = LinuxSpoofer()


### PR DESCRIPTION
Alternate fix for https://github.com/feross/SpoofMAC/pull/58#issuecomment-168454782 on OpenSUSE 42.1.