### PR TITLE
Fix for macos 15

### DIFF
--- a/spoofmac/interface.py
+++ b/spoofmac/interface.py
@@ -442,8 +442,17 @@ class MacSpoofer(OsSpoofer):
         # For some reason this seems to be required even when changing a
         # non-airport device.
         subprocess.check_call([
-            MacSpoofer.PATH_TO_AIRPORT,
-            '-z'
+            'networksetup',
+            '-setairportpower',
+            device,
+            'off'
+        ])
+
+        subprocess.check_call([
+            'networksetup',
+            '-setairportpower',
+            device,
+            'on'
         ])
 
         # Change the MAC.


### PR DESCRIPTION
instead of using airport utility, that is being deprecated, you can just turn off and on the device.